### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/ethereum-cat-herders/EIPIP/badge)](https://www.gitpoap.io/gh/ethereum-cat-herders/EIPIP)
+
 ### Purpose
 The EIPIP meeting is a regularly-scheduled process improvement meeting intended to bring together experienced developers and experts to facilitate the [Ethereum Improvement Proposal](https://github.com/ethereum/EIPs) improvement process.
 


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie